### PR TITLE
added authentication on user CRUD and changed signup

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -20,27 +20,33 @@ module Api
 
       # POST /users
       def create
-        @user = User.new(user_params)
+        if @current_user.role == 1
+          @user = User.new(user_params)
 
-        if @user.save
-          render json: @user, status: :created, location: @user
-        else
-          render json: @user.errors, status: :unprocessable_entity
+          if @user.save
+            render json: @user, status: :created, location: @user
+          else
+            render json: @user.errors, status: :unprocessable_entity
+          end
         end
       end
 
       # PATCH/PUT /users/1
       def update
-        if @user.update(user_params)
-          render json: @user
-        else
-          render json: @user.errors, status: :unprocessable_entity
+        if @current_user.role == 1
+          if @user.update(user_params)
+            render json: @user
+          else
+            render json: @user.errors, status: :unprocessable_entity
+          end
         end
       end
 
       # DELETE /users/1
       def destroy
-        @user.destroy
+        if @current_user.role == 1
+          @user.destroy
+        end
       end
 
       private
@@ -51,7 +57,7 @@ module Api
 
         # Only allow a trusted parameter "white list" through.
         def user_params
-          params.require(:user).permit(:userName)
+          params.require(:user).permit(:email, :password, :password_confirmation, :role)
         end
 
         def current_user

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -6,10 +6,10 @@ class SignupController < ApplicationController
       session = JWTSessions::Session.new(payload: payload, refresh_by_access_allowed: true)
       tokens = session.login
 
-      response.set_cookie(JWTSessions.access_cookie,
-                          value: tokens[:access],
-                          httponly: true,
-                          secure: Rails.env.production?)
+      # response.set_cookie(JWTSessions.access_cookie,
+      #                     value: tokens[:access],
+      #                     httponly: true,
+      #                     secure: Rails.env.production?)
       render json: { csrf: tokens[:csrf] }
     else
       render json: { error: user.errors.full_messages.join(' ') }, status: :unprocessable_entity


### PR DESCRIPTION
All actions on users (including viewing them) require an admin account now. Admin accounts can be set by creating a user with the role attribute set to 1.

On user creation, there is no token change and the current user does not log out anymore (fix)